### PR TITLE
Connect interrupts

### DIFF
--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_interrupt_timer_seq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_interrupt_timer_seq.sv
@@ -49,7 +49,12 @@ endfunction : new
 
 task uvme_cv32e40p_vp_interrupt_timer_seq_c::set_interrupt();
 
-   cv32e40p_cntxt.interrupt_cntxt.vif.drv_cb.irq_drv <= interrupt_value;
+   if (cv32e40p_cntxt.interrupt_cntxt.vif != null) begin
+      cv32e40p_cntxt.interrupt_cntxt.vif.drv_cb.irq_drv <= interrupt_value;
+   end
+   else begin
+      `uvm_fatal("InterruptTimer_Seq", "cv32e40p_cntxt.interrupt_cntxt.vif does NOT exist")
+   end
 
 endtask : set_interrupt
 

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_sig_writer_seq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_sig_writer_seq.sv
@@ -58,6 +58,9 @@ task uvme_cv32e40p_vp_sig_writer_seq_c::body();
    if (cv32e40p_cntxt == null) begin
       `uvm_fatal("E40PVPSTATUS", "Must initialize cv32e40p_cntxt in virtual peripheral")
    end
+   else begin
+      `uvm_info("E40PVPSTATUS", "cv32e40p_cntxt initialized in virtual peripheral", UVM_NONE)
+   end
 
    super.body();
 

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -17,7 +17,8 @@ export SHELL = /bin/bash
 #CV_CORE_BRANCH ?= dev
 #CV_CORE_HASH   ?= bddbd38fb0b5ced6208090691002b7ee021dcc8d
 CV_CORE_REPO   ?= https://github.com/YoannPruvost/cv32e40p
-CV_CORE_BRANCH ?= dev_rvfi_clean
+#CV_CORE_BRANCH ?= dev_rvfi_clean
+CV_CORE_BRANCH ?= dev_rvfi_clean_interrupt_bug
 CV_CORE_HASH   ?= head
 CV_CORE_TAG    ?= none
 # The CV_CORE_HASH above points to version of the RTL that is newer, but

--- a/cv32e40p/sim/ExternalRepos.mk
+++ b/cv32e40p/sim/ExternalRepos.mk
@@ -13,9 +13,12 @@
 
 export SHELL = /bin/bash
 
-CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
-CV_CORE_BRANCH ?= dev
-CV_CORE_HASH   ?= bddbd38fb0b5ced6208090691002b7ee021dcc8d
+#CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
+#CV_CORE_BRANCH ?= dev
+#CV_CORE_HASH   ?= bddbd38fb0b5ced6208090691002b7ee021dcc8d
+CV_CORE_REPO   ?= https://github.com/YoannPruvost/cv32e40p
+CV_CORE_BRANCH ?= dev_rvfi_clean
+CV_CORE_HASH   ?= head
 CV_CORE_TAG    ?= none
 # The CV_CORE_HASH above points to version of the RTL that is newer, but
 # ilogically equivalent RTL with respect to v1.0.0 RTL freeze version.

--- a/cv32e40p/sim/uvmt/.simvision/108338_v51366_vcl-vm0-109_autosave.tcl.svcf
+++ b/cv32e40p/sim/uvmt/.simvision/108338_v51366_vcl-vm0-109_autosave.tcl.svcf
@@ -1,0 +1,154 @@
+
+#
+# Preferences
+#
+preferences set plugin-enable-svdatabrowser-new 1
+preferences set toolbar-Standard-WaveWindow {
+  usual
+  position -pos 1
+}
+preferences set plugin-enable-groupscope 0
+preferences set plugin-enable-interleaveandcompare 0
+preferences set plugin-enable-waveformfrequencyplot 0
+
+#
+# Databases
+#
+database require waves -search {
+	./xrun_results/default/interrupt_test/0/waves.shm/waves.trn
+	/home/v51366/mydata/GitHubRepos/MikeOpenHWGroup/core-v-verif/cv32e40p/dev_rvfi/cv32e40p/sim/uvmt/xrun_results/default/interrupt_test/0/waves.shm/waves.trn
+}
+
+#
+# Mnemonic Maps
+#
+mmap new -reuse -name {Boolean as Logic} -radix %b -contents {{%c=FALSE -edgepriority 1 -shape low}
+{%c=TRUE -edgepriority 1 -shape high}}
+mmap new -reuse -name {Example Map} -radix %x -contents {{%b=11???? -bgcolor orange -label REG:%x -linecolor yellow -shape bus}
+{%x=1F -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=2C -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=* -label %x -linecolor gray -shape bus}}
+
+#
+# Waveform windows
+#
+if {[catch {window new WaveWindow -name "Waveform 1" -geometry 1748x592+70+54}] != ""} {
+    window geometry "Waveform 1" 1748x592+70+54
+}
+window target "Waveform 1" on
+waveform using {Waveform 1}
+waveform sidebar select designbrowser
+waveform set \
+    -primarycursor TimeA \
+    -signalnames name \
+    -signalwidth 175 \
+    -units ns \
+    -valuewidth 75
+waveform baseline set -time 0
+
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.clk
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.cycle_cnt[31:0]}
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.reset_n
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_dbg[2:0]}
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_dbg_mode
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_halt
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_insn[31:0]}
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_intr
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_ixl[1:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mem_addr[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mem_rdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mem_rmask[3:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mem_wdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mem_wmask[3:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_mode[1:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_order[63:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_pc_rdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_pc_wdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rd1_addr[4:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rd1_wdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rd2_addr[4:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rd2_wdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs1_addr[4:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs1_rdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs2_addr[4:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs2_rdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs3_addr[4:0]}
+	} ]
+set id [waveform add -signals  {
+	{waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_rs3_rdata[31:0]}
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_trap
+	} ]
+set id [waveform add -signals  {
+	waves::uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_valid
+	} ]
+
+waveform xview limits 0 85878.3ns
+
+#
+# Waveform Window Links
+#
+
+#
+# Console windows
+#
+console set -windowname Console
+window geometry Console 600x250+0+0
+
+#
+# Layout selection
+#

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -220,7 +220,7 @@ function void uvmt_cv32e40p_base_test_c::build_phase(uvm_phase phase);
 
    super.build_phase(phase);
 
-   rs.set_max_quit_count(.count(5), .overridable(1));
+   rs.set_max_quit_count(.count(10), .overridable(1));
 
    create_cfg       ();
    cfg_hrtbt_monitor();

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -176,10 +176,6 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
             mon_trn.csrs[csr] = csr_trn;
          end
 
-         if (mon_trn.intr) begin
-            `uvm_fatal(log_tag, "INTR")
-         end
-
          // Determine if interrupt is nmi or interrupt
          mon_trn.insn_nmi        = 0;
          mon_trn.insn_interrupt  = 0;

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -176,6 +176,10 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
             mon_trn.csrs[csr] = csr_trn;
          end
 
+         if (mon_trn.intr) begin
+            `uvm_fatal(log_tag, "INTR")
+         end
+
          // Determine if interrupt is nmi or interrupt
          mon_trn.insn_nmi        = 0;
          mon_trn.insn_interrupt  = 0;

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_drv.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_drv.sv
@@ -127,6 +127,13 @@ task uvma_rvvi_ovpsim_drv_c::stepi(REQ req);
    if (!$cast(rvvi_ovpsim_seq_item, req)) begin
       `uvm_fatal(log_tag, "Failed to cast control_seq_item to ovpsim_control_seq_item");
    end
+   else begin
+      `uvm_info(log_tag, $sformatf("%s", rvvi_ovpsim_seq_item.convert2string()), UVM_DEBUG)
+      if (rvvi_ovpsim_seq_item.intr) begin
+         `uvm_info ("UVMA_RVVI_OVPSIM_DRV", $sformatf("irq_i = %x", rvvi_ovpsim_cntxt.ovpsim_io_vif.irq_i), UVM_NONE)
+         rvvi_ovpsim_seq_item.print();
+      end
+   end
 
    // Stop the clock
    stop_clknrst();
@@ -197,6 +204,8 @@ task uvma_rvvi_ovpsim_drv_c::stepi(REQ req);
 
    // Signal an interrupt to the ISS if mcause and rvfi_intr signals external interrupt
    if (rvvi_ovpsim_seq_item.intr) begin
+      `uvm_info ("UVMA_RVVI_OVPSIM_DRV", $sformatf("irq_i = %x", rvvi_ovpsim_cntxt.ovpsim_io_vif.irq_i), UVM_NONE)
+      rvvi_ovpsim_seq_item.print();
       rvvi_ovpsim_cntxt.ovpsim_io_vif.deferint = 1'b0;
       rvvi_ovpsim_cntxt.ovpsim_io_vif.irq_i    = 1 << (rvvi_ovpsim_seq_item.intr_id);
       rvvi_ovpsim_cntxt.control_vif.stepi();


### PR DESCRIPTION
Hi @YoannPruvost, this PR will connect the interrupts generated by the Interrupt Virtual Peripheral to the core.   The test fails, but I am not sure if it is a testbench issue.

Note that not all changes are strictly necessary - I added in some debug code for my own use.  It is safe to keep it, but not necessary for functionality.